### PR TITLE
fix. 极端网络下传递线索卡住

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -3117,6 +3117,25 @@
             "ClueGiveTo1stConfirm"
         ]
     },
+    "ClueGiveLoading": {
+        "algorithm": "OcrDetect",
+        "action": "doNothing",
+        "text": [
+            "正在提交",
+            "反馈至神经"
+        ],
+        "roi": [
+            700,
+            600,
+            300,
+            120
+        ],
+        "next": [
+            "ClueGiveLoading",
+            "SelectClue",
+            "CloseSendClue"
+        ]
+    },
     "ClueGiveTo1st": {
         "template": "ClusCanBeSent.png",
         "action": "doNothing",
@@ -3145,6 +3164,7 @@
             160
         ],
         "next": [
+            "ClueGiveLoading",
             "SelectClue",
             "CloseSendClue"
         ]
@@ -3177,6 +3197,7 @@
             160
         ],
         "next": [
+            "ClueGiveLoading",
             "SelectClue",
             "CloseSendClue"
         ]
@@ -3209,6 +3230,7 @@
             160
         ],
         "next": [
+            "ClueGiveLoading",
             "SelectClue",
             "CloseSendClue"
         ]
@@ -3241,6 +3263,7 @@
             160
         ],
         "next": [
+            "ClueGiveLoading",
             "SelectClue",
             "CloseSendClue"
         ]


### PR DESCRIPTION
原本在传递完一个线索后，会尝试传递下一个线索。在传递这个线索时，首先会在左侧选择它，然后在右边找能传的好友，找不到就翻页。由于方舟加载较慢，没有选中线索，右侧好友栏中找不到能传的对象，会不停的翻页后卡在最后一页。